### PR TITLE
Add Cursor agent context and living project timeline

### DIFF
--- a/.cursor/README.md
+++ b/.cursor/README.md
@@ -12,8 +12,7 @@ Keep it small — prefer updating existing files over adding new ones.
 | [`rules/`](rules/) | Cursor rules (`.mdc`) |
 | [`plans/`](plans/) | Short-lived feature/chore plans (delete when done) |
 
-Root pointers: [`AGENTS.md`](../AGENTS.md). Human docs: [`README.md`](../README.md),
-[`ONEDRIVE_SETUP.md`](../ONEDRIVE_SETUP.md).
+Root pointers: [`AGENTS.md`](../AGENTS.md). Human docs: [`README.md`](../README.md).
 
 ## Conventions
 

--- a/.cursor/README.md
+++ b/.cursor/README.md
@@ -1,0 +1,23 @@
+# Cursor project folder
+
+Canonical, versioned home for shared agent context on this Hugo site.
+Keep it small — prefer updating existing files over adding new ones.
+
+## Layout
+
+| Path | Purpose |
+|------|---------|
+| [`context/PROJECT.md`](context/PROJECT.md) | Stack, layout, commands, conventions |
+| [`context/TIMELINE.md`](context/TIMELINE.md) | Living log of ownership, infra, and product milestones |
+| [`rules/`](rules/) | Cursor rules (`.mdc`) |
+| [`plans/`](plans/) | Short-lived feature/chore plans (delete when done) |
+
+Root pointers: [`AGENTS.md`](../AGENTS.md). Human docs: [`README.md`](../README.md),
+[`ONEDRIVE_SETUP.md`](../ONEDRIVE_SETUP.md).
+
+## Conventions
+
+- **Timeline**: newest entries at the top. One short bullet per material change.
+- **Plans**: name descriptively; delete when finished rather than letting them rot.
+- **Rules**: keep under ~50 lines; one concern per file.
+- Context updates belong in the same PR as the code they describe.

--- a/.cursor/context/PROJECT.md
+++ b/.cursor/context/PROJECT.md
@@ -1,0 +1,65 @@
+# Sporting Chance — project context
+
+Marketing / information site for **The Sporting Chance Project** (alternative
+learning provision). Static site only — no app backend.
+
+## Stack
+
+| Layer | Choice |
+|-------|--------|
+| SSG | Hugo (`HUGO_VERSION` 0.121.0 on Netlify) |
+| CSS | Tailwind 3 (`tailwind.js` brand tokens as `sc-*` classes) |
+| JS/CSS build | Webpack 5 + PostCSS (`src/` → compiled assets) |
+| Package manager | Yarn 4 (`packageManager` in `package.json`) |
+| Local Hugo | Docker (`docker-compose.yml`, port 1313) |
+| Hosting | Netlify — production deploys from `master` |
+| CMS (legacy) | Forestry.io noted in README; content is plain Markdown in git |
+
+## Repo layout
+
+| Path | Role |
+|------|------|
+| `content/` | Page Markdown (home `_index.md`, about, services, policies, etc.) |
+| `content/policies/` | Policy pages; embed OneDrive docs via `iframe_url` front matter |
+| `layouts/` | Hugo templates (`_default`, `page`, `policies`, `partials/`) |
+| `layouts/partials/blocks/` | Reusable content blocks |
+| `src/css`, `src/js` | Source assets compiled by Webpack |
+| `static/` | Static files served as-is |
+| `config.toml` | Site config, main menu, params |
+| `netlify.toml` | Build command + Hugo/Node versions |
+| `ONEDRIVE_SETUP.md` | How to embed password-protected policy docs from OneDrive |
+
+## Commands
+
+```bash
+yarn            # install
+yarn dev        # Docker Hugo + webpack --watch → http://localhost:1313
+yarn build      # webpack production build
+yarn start      # hugo server (needs local Hugo; prefer yarn dev)
+```
+
+Netlify build: `yarn install && yarn build && hugo` → publish `public/`.
+
+## Git workflow
+
+| Branch | Role |
+|--------|------|
+| `master` | Production (Netlify production branch) |
+| `develop` | Integration / staging (enable Netlify branch deploys when available) |
+| `feature/*`, `chore/*` | Work branches → PR into `develop`, then promote to `master` |
+
+## Conventions
+
+- Prefer Tailwind utility classes in templates; brand colours via `sc-*` from `tailwind.js`.
+- Content edits live in `content/**/*.md`; structural/UI in `layouts/`.
+- Policy embeds: set `iframe_url` in front matter — see `ONEDRIVE_SETUP.md`.
+- Do not commit on the user's behalf unless explicitly asked.
+- After material ownership, hosting, or architecture changes, update
+  [`TIMELINE.md`](TIMELINE.md) in the same PR.
+
+## Ownership / access (as of Aug 2026)
+
+- GitHub repo historically under `Ieuanoh/SportingChance`; transfer or fork
+  to SCP/maintainer in progress.
+- Netlify account access may still sit with the previous maintainer — confirm
+  before changing deploy settings or domains.

--- a/.cursor/context/PROJECT.md
+++ b/.cursor/context/PROJECT.md
@@ -27,7 +27,6 @@ learning provision). Static site only — no app backend.
 | `static/` | Static files served as-is |
 | `config.toml` | Site config, main menu, params |
 | `netlify.toml` | Build command + Hugo/Node versions |
-| `ONEDRIVE_SETUP.md` | How to embed password-protected policy docs from OneDrive |
 
 ## Commands
 
@@ -52,7 +51,7 @@ Netlify build: `yarn install && yarn build && hugo` → publish `public/`.
 
 - Prefer Tailwind utility classes in templates; brand colours via `sc-*` from `tailwind.js`.
 - Content edits live in `content/**/*.md`; structural/UI in `layouts/`.
-- Policy embeds: set `iframe_url` in front matter — see `ONEDRIVE_SETUP.md`.
+- Policy embeds: set `iframe_url` in front matter (OneDrive setup docs live on the policies feature branch when present).
 - Do not commit on the user's behalf unless explicitly asked.
 - After material ownership, hosting, or architecture changes, update
   [`TIMELINE.md`](TIMELINE.md) in the same PR.

--- a/.cursor/context/TIMELINE.md
+++ b/.cursor/context/TIMELINE.md
@@ -8,7 +8,7 @@ Update in the same PR as the change. Keep entries to one short bullet.
 - **Cursor context** — Added `.cursor/` + `AGENTS.md` as the starting point for AI-assisted maintenance (this file, `PROJECT.md`, project rules).
 - **`develop` branch** — Created from `master` as the integration branch; Netlify branch deploys for preview still pending account access.
 - **Maintainer handover** — Lead maintenance moving to Matt / SCP; GitHub transfer and Netlify access requested from previous owner (`Ieuanoh`).
-- **Policy docs** — Site direction is OneDrive (Microsoft 365) embeds with optional link passwords; see `ONEDRIVE_SETUP.md`. Embed URL wiring may still be in progress on a feature branch.
+- **Policy docs** — Site direction is OneDrive (Microsoft 365) embeds with optional link passwords. Setup notes and embed URL wiring may still be in progress on a feature branch.
 
 ## Earlier (pre-handover)
 

--- a/.cursor/context/TIMELINE.md
+++ b/.cursor/context/TIMELINE.md
@@ -1,0 +1,17 @@
+# Timeline
+
+Living log of material project changes. **Newest first.**
+Update in the same PR as the change. Keep entries to one short bullet.
+
+## 2026-08
+
+- **Cursor context** — Added `.cursor/` + `AGENTS.md` as the starting point for AI-assisted maintenance (this file, `PROJECT.md`, project rules).
+- **`develop` branch** — Created from `master` as the integration branch; Netlify branch deploys for preview still pending account access.
+- **Maintainer handover** — Lead maintenance moving to Matt / SCP; GitHub transfer and Netlify access requested from previous owner (`Ieuanoh`).
+- **Policy docs** — Site direction is OneDrive (Microsoft 365) embeds with optional link passwords; see `ONEDRIVE_SETUP.md`. Embed URL wiring may still be in progress on a feature branch.
+
+## Earlier (pre-handover)
+
+- Hugo + Tailwind + Webpack site hosted on Netlify from `master`.
+- Forestry.io used historically as a git-backed CMS for `content/`.
+- Policies & procedures section added (list + single layouts under `layouts/policies/`).

--- a/.cursor/plans/README.md
+++ b/.cursor/plans/README.md
@@ -1,0 +1,4 @@
+# Plans
+
+Drop short-lived feature or chore plans here while work is active.
+Delete the file when the work ships — do not accumulate finished plans.

--- a/.cursor/rules/project.mdc
+++ b/.cursor/rules/project.mdc
@@ -1,0 +1,24 @@
+---
+description: Sporting Chance site conventions for agents
+alwaysApply: true
+---
+
+# Sporting Chance
+
+Hugo + Tailwind + Webpack static site. Read `.cursor/context/PROJECT.md` for
+stack and layout. Keep `.cursor/context/TIMELINE.md` current when ownership,
+hosting, or architecture changes.
+
+## Do
+
+- Edit page copy in `content/`; templates in `layouts/`; assets in `src/`.
+- Use existing Tailwind / `sc-*` brand classes before adding custom CSS.
+- For policy embeds, follow `ONEDRIVE_SETUP.md` (`iframe_url` front matter).
+- Prefer PRs into `develop`; leave `master` for production releases.
+- Prefer updating `PROJECT.md` / `TIMELINE.md` over creating new context docs.
+
+## Don't
+
+- Don't add app/backend scaffolding — this is a static marketing site.
+- Don't invent a large docs tree; two context files plus rules are enough.
+- Don't commit unless the user explicitly asks.

--- a/.cursor/rules/project.mdc
+++ b/.cursor/rules/project.mdc
@@ -13,7 +13,7 @@ hosting, or architecture changes.
 
 - Edit page copy in `content/`; templates in `layouts/`; assets in `src/`.
 - Use existing Tailwind / `sc-*` brand classes before adding custom CSS.
-- For policy embeds, follow `ONEDRIVE_SETUP.md` (`iframe_url` front matter).
+- For policy embeds, set `iframe_url` in front matter (OneDrive embed docs when that file is on the branch).
 - Prefer PRs into `develop`; leave `master` for production releases.
 - Prefer updating `PROJECT.md` / `TIMELINE.md` over creating new context docs.
 

--- a/.cursor/rules/update-timeline.mdc
+++ b/.cursor/rules/update-timeline.mdc
@@ -1,0 +1,16 @@
+---
+description: Keep TIMELINE.md current when material project facts change
+alwaysApply: true
+---
+
+# Living context
+
+When a change affects how this site is owned, built, deployed, or maintained,
+add a short dated bullet to `.cursor/context/TIMELINE.md` (newest first) in the
+same PR. Update `.cursor/context/PROJECT.md` only if the overview would otherwise
+be wrong.
+
+Examples that need a timeline entry: branch/deploy workflow, Netlify/GitHub
+ownership, policy document hosting, stack upgrades, CMS changes.
+
+Skip timeline noise for routine copy edits and small UI tweaks.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,7 +16,7 @@ inside is plain Markdown and agent-agnostic.
 | Short-lived plans | [`.cursor/plans/`](.cursor/plans/) |
 | Folder index | [`.cursor/README.md`](.cursor/README.md) |
 
-Human docs: [`README.md`](README.md), [`ONEDRIVE_SETUP.md`](ONEDRIVE_SETUP.md).
+Human docs: [`README.md`](README.md).
 
 ## Keeping context alive
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,25 @@
+# AGENTS.md
+
+This repository uses [`.cursor/`](.cursor/) as the **canonical, versioned
+home for shared agent context** (project notes, rules, timeline).
+
+The folder is named `.cursor/` so Cursor auto-discovers `rules/`. Content
+inside is plain Markdown and agent-agnostic.
+
+## Where to look
+
+| Need | Path |
+|------|------|
+| Project overview, stack, paths, commands | [`.cursor/context/PROJECT.md`](.cursor/context/PROJECT.md) |
+| Living history of decisions & milestones | [`.cursor/context/TIMELINE.md`](.cursor/context/TIMELINE.md) |
+| Agent rules (Cursor `.mdc`; body is plain Markdown) | [`.cursor/rules/`](.cursor/rules/) |
+| Short-lived plans | [`.cursor/plans/`](.cursor/plans/) |
+| Folder index | [`.cursor/README.md`](.cursor/README.md) |
+
+Human docs: [`README.md`](README.md), [`ONEDRIVE_SETUP.md`](ONEDRIVE_SETUP.md).
+
+## Keeping context alive
+
+When a change alters how the site is built, deployed, or maintained, update
+**TIMELINE.md** (and PROJECT.md if the overview is stale) in the same PR.
+Do not create new context docs unless something does not fit those files.

--- a/README.md
+++ b/README.md
@@ -19,5 +19,8 @@ The Sporting Chance website, built using Hugo.
 ## Deployment
 
 - Netlify currently deploys the site on each push of the master branch of the repository
+- Integration work should target the `develop` branch; promote to `master` for production
 
-TODO
+## Agent / AI context
+
+Shared project context for Cursor (and other agents) lives under [`.cursor/`](.cursor/) — start at [`AGENTS.md`](AGENTS.md). Update [`.cursor/context/TIMELINE.md`](.cursor/context/TIMELINE.md) when material ownership, hosting, or architecture facts change.


### PR DESCRIPTION
## Summary
- Add versioned agent context under `.cursor/` plus `AGENTS.md` so AI-assisted maintenance has a clear stack, layout, and workflow reference.
- Introduce a living timeline and rules that keep ownership, hosting, and architecture notes updated in the same PR as related changes.

## What changed
- `.cursor/context/PROJECT.md` — stack, repo layout, commands, git workflow, ownership notes
- `.cursor/context/TIMELINE.md` — dated log of handover, `develop` branch, policy-doc direction, and Cursor setup
- `.cursor/rules/` — always-on project conventions and timeline-update guidance
- `AGENTS.md` + `.cursor/README.md` — entry points for agents
- `README.md` — points humans at agent context and the `develop` → `master` workflow

## Why
With maintainer handover underway, shared project facts need a single place agents (and humans) can trust, instead of rediscovering them each session.

## Test plan
- [X] Confirm links in `AGENTS.md` and `.cursor/README.md` resolve in GitHub
- [X] Spot-check `PROJECT.md` against current `netlify.toml` / `package.json` (Hugo/Node versions)
- [X] No site build required — docs-only change