### PR TITLE
chore: update timeline with identified work and backlog reference

### DIFF
--- a/.cursor/context/TIMELINE.md
+++ b/.cursor/context/TIMELINE.md
@@ -5,6 +5,7 @@ Update in the same PR as the change. Keep entries to one short bullet.
 
 ## 2026-08
 
+- **Identified work (Tony / Matt)** — Captured brief plans for OneDrive policy embeds (restore access), a homepage banner to Supporting Children's Pathways, and a content/testimonials/imagery refresh; see `.cursor/plans/REQUIREMENTS.md`.
 - **Cursor context** — Added `.cursor/` + `AGENTS.md` as the starting point for AI-assisted maintenance (this file, `PROJECT.md`, project rules).
 - **`develop` branch** — Created from `master` as the integration branch; Netlify branch deploys for preview still pending account access.
 - **Maintainer handover** — Lead maintenance moving to Matt / SCP; GitHub transfer and Netlify access requested from previous owner (`Ieuanoh`).

--- a/.cursor/plans/README.md
+++ b/.cursor/plans/README.md
@@ -2,3 +2,5 @@
 
 Drop short-lived feature or chore plans here while work is active.
 Delete the file when the work ships — do not accumulate finished plans.
+
+Identified backlog (Tony / Matt): [REQUIREMENTS.md](REQUIREMENTS.md).

--- a/.cursor/plans/REQUIREMENTS.md
+++ b/.cursor/plans/REQUIREMENTS.md
@@ -1,0 +1,11 @@
+# Identified requirements (Tony / Matt)
+
+Short backlog captured 2026-08. Each item has a brief plan; detailed design happens when the task starts.
+
+| Plan | Summary | Existing work |
+|------|---------|---------------|
+| [onedrive-policy-embeds.md](onedrive-policy-embeds.md) | Policies moved to OneDrive; restore accessible embeds | Local `feature/update-policies-and-procedures` (WIP) |
+| [homepage-scp-banner.md](homepage-scp-banner.md) | Homepage banner linking to Supporting Children's Pathways | None yet |
+| [content-testimonials-imagery.md](content-testimonials-imagery.md) | Content refresh, new testimonials, source/add pictures | Testimonials page + `feedback-quote` block already exist; images TBD with Tony |
+
+Delete individual plan files (and this index if empty) when the work ships.

--- a/.cursor/plans/content-testimonials-imagery.md
+++ b/.cursor/plans/content-testimonials-imagery.md
@@ -1,0 +1,36 @@
+# Content update, testimonials, and imagery
+
+**Status:** Identified (Tony / Matt) — brief only; detailed planning when work starts  
+**Priority:** Medium — refresh site copy and social proof; imagery blocked on sourcing  
+**Suggested branch:** `feature/content-and-testimonials` from `develop` (split imagery into a follow-up PR if photos arrive late)
+
+## Goal
+
+Update site content with Tony, add/refresh **testimonials**, and bring in new **pictures** once assets are sourced and cleared for use.
+
+## Existing building blocks
+
+- Testimonials page: `content/Testimonials.md` (uses `feedback-quote` sections)
+- Quote block: `layouts/partials/blocks/feedback-quote.html`
+- Homepage / about / services already embed some quotes via the same template
+- Images live under `static/img/` (mix of Unsplash stock and older site assets)
+
+## Brief plan
+
+1. **Copy pass with Tony** — Agree which pages need rewrites (home, about, services, ALP, mentoring, etc.) and collect final wording.
+2. **Testimonials** — Gather new quotes (attribution, consent, anonymisation rules). Add to `/testimonials` and decide which appear on home / key service pages.
+3. **Imagery** — List shots needed (hero, about, activity, team/partner). Arrange sourcing with Tony (own photos vs commissioned vs stock). Confirm model/parent consent and usage rights before committing files.
+4. Implement approved copy + quotes in `content/`; drop cleared images into `static/img/` and wire paths in front matter / templates.
+5. Visual QA on desktop and mobile; PR into `develop`. Delete this plan when shipped.
+
+## Dependencies / sequencing
+
+- Content and testimonials can land without new photos if needed.
+- Picture work waits on sourcing + consent — do not block the copy PR on assets that are still outstanding.
+
+## Open questions (defer to task kickoff)
+
+- Full list of pages in scope for this pass
+- Whether old testimonials stay, get edited, or are replaced
+- Photo style (real provision photos preferred over more stock)
+- Who stores originals / naming conventions for new assets

--- a/.cursor/plans/homepage-scp-banner.md
+++ b/.cursor/plans/homepage-scp-banner.md
@@ -1,0 +1,29 @@
+# Homepage banner → Supporting Children's Pathways
+
+**Status:** Identified (Tony / Matt) — brief only; detailed planning when work starts  
+**Priority:** Medium — cross-site signposting for the sister charity  
+**Suggested branch:** `feature/homepage-scp-banner` from `develop`
+
+## Goal
+
+Add a clear banner at the **top of the homepage** that links visitors to the sister site **Supporting Children's Pathways** (sibling repo: [`SCPCharity`](https://github.com/HandMatt/SCPCharity), production URL: https://www.supportingchildrenspathways.org/).
+
+## Context
+
+- This site already has a homepage **hero** (`hero_banner` → `layouts/partials/hero-banner.html`). The new item is a separate **top-of-page site notice / signpost**, not a hero redesign.
+- Sister site is a different Hugo project under `/home/matt/development/work/SCPCharity`.
+
+## Brief plan
+
+1. Agree copy with Tony (one short line + CTA label) and confirm the destination URL (home vs a specific landing page).
+2. Add a slim full-width banner above the main nav (or between nav and hero — decide at kickoff for visibility vs clutter).
+3. Homepage-only unless Tony wants it site-wide; prefer content/config driven (front matter or `config.toml` params) over hardcoding in the template.
+4. Match existing Tailwind / `sc-*` brand tokens; keep it one job (signpost), no card clutter.
+5. Check mobile: dismissible or not (default: not dismissible unless requested); link opens in same or new tab (confirm).
+6. PR into `develop`; delete this plan when shipped.
+
+## Open questions (defer to task kickoff)
+
+- Exact wording and visual weight (subtle bar vs stronger callout)
+- Homepage only vs all pages
+- Whether SCP should reciprocate with a banner back to Sporting Chance

--- a/.cursor/plans/onedrive-policy-embeds.md
+++ b/.cursor/plans/onedrive-policy-embeds.md
@@ -1,0 +1,32 @@
+# Restore accessible policy documents (OneDrive)
+
+**Status:** Identified (Tony / Matt) — brief only; detailed planning when work starts  
+**Priority:** High — policies are currently not accessible on the live site  
+**Suggested branch:** rebase / finish `feature/update-policies-and-procedures` onto `develop` (or a fresh `feature/onedrive-policy-embeds` from `develop` if cleaner)
+
+## Problem
+
+Policy PDFs moved off Google Drive onto OneDrive (Microsoft 365). The live site still points at Google Drive embeds (or placeholders), so visitors cannot view policies.
+
+## Existing work
+
+Local WIP branch `feature/update-policies-and-procedures` already:
+
+- Replaces `GOOGLE_DRIVE_SETUP.md` with `ONEDRIVE_SETUP.md`
+- Clears / retargets `iframe_url` front matter on policy pages
+- Tweaks `layouts/policies/single.html` copy for OneDrive
+
+Embed URLs were left TBD (`iframe_url: ""` on at least safeguarding). That branch predates `chore/cursor-project-context` / `develop` — rebase or cherry-pick before finishing.
+
+## Brief plan
+
+1. Confirm with Tony where the canonical OneDrive/SharePoint folder lives and that “Anyone + password” sharing is allowed on the tenant.
+2. For each policy page under `content/policies/`, generate a OneDrive/SharePoint **embed** URL and set `iframe_url` (see `ONEDRIVE_SETUP.md` on the WIP branch).
+3. Smoke-test each policy page: iframe loads, password prompt works, mobile layout OK.
+4. Land docs + content via PR into `develop`; delete the plan file when shipped.
+
+## Open questions (defer to task kickoff)
+
+- Exact list of policies that must ship (all current pages vs a subset)
+- Whether passwords stay the same as the old Google Drive ones
+- Whether download should be blocked on the share links


### PR DESCRIPTION
## Summary
- Add versioned Cursor/agent project context (`.cursor/`, `AGENTS.md`) so maintenance work has a shared stack overview, timeline, and rules.
- Capture the Tony/Matt identified backlog as short plans (OneDrive policy embeds, homepage SCP banner, content/testimonials/imagery refresh).
- Point humans at the same context from `README.md`, and document `develop` as the integration branch.

## What changed
- `.cursor/context/`: `PROJECT.md` overview and living `TIMELINE.md`
- `.cursor/rules/`: project conventions and timeline-update guidance
- `.cursor/plans/`: `REQUIREMENTS.md` index plus three brief plan files
- `AGENTS.md` entry point; light `README.md` updates for workflow and agent docs

## Test plan
- [X] Skim `AGENTS.md` → `PROJECT.md` / `TIMELINE.md` / `REQUIREMENTS.md` and confirm paths and facts look right
- [X] Confirm plan summaries match the agreed near-term work (no site/build changes in this PR)