### PR TITLE
Run local Webpack via Docker Compose assets service

### DIFF
--- a/.cursor/context/PROJECT.md
+++ b/.cursor/context/PROJECT.md
@@ -11,7 +11,7 @@ learning provision). Static site only — no app backend.
 | CSS | Tailwind 3 (`tailwind.js` brand tokens as `sc-*` classes) |
 | JS/CSS build | Webpack 5 + PostCSS (`src/` → compiled assets) |
 | Package manager | Yarn 4 (`packageManager` in `package.json`) |
-| Local Hugo | Docker (`docker-compose.yml`, port 1313) |
+| Local dev | Docker Compose - `hugo` + `assets` (Node 18 / Yarn 4); site on port 1313 |
 | Hosting | Netlify — production deploys from `master` |
 | CMS (legacy) | Forestry.io noted in README; content is plain Markdown in git |
 
@@ -27,14 +27,18 @@ learning provision). Static site only — no app backend.
 | `static/` | Static files served as-is |
 | `config.toml` | Site config, main menu, params |
 | `netlify.toml` | Build command + Hugo/Node versions |
+| `docker-compose.yml` | Local `hugo` + `assets` services |
+| `Dockerfile.assets`| Node 18 image with Yarn 4.9.2 (Corepack) |
+| `.yarnrc.yml` | `nodeLinker: node-modules` (required for Webpack) |
 
 ## Commands
 
 ```bash
-yarn            # install
-yarn dev        # Docker Hugo + webpack --watch → http://localhost:1313
-yarn build      # webpack production build
-yarn start      # hugo server (needs local Hugo; prefer yarn dev)
+docker compose build assets                   # first time / Dockerfile changes
+docker compose run --rm assets yarn install   # first time / after dep changes
+docker compose up                             # or: yarn dev -> http://localhost:1313
+yarn build                                    # webpack once (Netlify / host Node)
+yarn start                                    # local Hugo only (needs Hugo on host)
 ```
 
 Netlify build: `yarn install && yarn build && hugo` → publish `public/`.

--- a/.cursor/context/TIMELINE.md
+++ b/.cursor/context/TIMELINE.md
@@ -5,6 +5,7 @@ Update in the same PR as the change. Keep entries to one short bullet.
 
 ## 2026-08
 
+- **Docker** — Moved local Node/Yarn into a Compose `assets` service so the site runs with Docker only; Netlify build unchanged.
 - **Identified work (Tony / Matt)** — Captured brief plans for OneDrive policy embeds (restore access), a homepage banner to Supporting Children's Pathways, and a content/testimonials/imagery refresh; see `.cursor/plans/REQUIREMENTS.md`.
 - **Cursor context** — Added `.cursor/` + `AGENTS.md` as the starting point for AI-assisted maintenance (this file, `PROJECT.md`, project rules).
 - **`develop` branch** — Created from `master` as the integration branch; Netlify branch deploys for preview still pending account access.

--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -1,0 +1,1 @@
+nodeLinker: node-modules

--- a/Dockerfile.assets
+++ b/Dockerfile.assets
@@ -1,0 +1,9 @@
+FROM node:18-bookworm
+
+WORKDIR /app
+
+# Match package.json "packageManager": "yarn@4.9.2"
+RUN corepack enable && corepack prepare yarn@4.9.2 --activate
+
+# Default: watch assets. Override with compose `run` for install/build.
+CMD ["yarn", "webpack", "--watch"]

--- a/README.md
+++ b/README.md
@@ -3,9 +3,11 @@ The Sporting Chance website, built using Hugo.
 # Getting Started
 
 - Install Docker
-- cd into the directory and install dependencies with `yarn`
-- Run the local site: `yarn dev` - this will run a dockerised version of the site to save needing to install hugo locally, it will also compile the css and js assets in the `src` folder - you can access the local site at http://localhost:1313
-- Alternatively, you can run it with the hugo cli if you don't want to use docker
+- First time (or after dependency changes):
+  - `docker compose build assets`
+  - `docker compose run --rm assets yarn install`
+- Run the local site: `docker compose up` (or `yarn dev`) - Hugo and Webpack in Docker; open http://localhost:1313
+- Optional: run with a local Hugo CLI and Node/Yarn if you prefer not to use Docker for everything
 
 ## Making styling updates
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,6 +5,15 @@ services:
       - 1313:1313
     volumes:
       - ./:/src
-      - ./static/:/src/static
     command: server --buildDrafts --buildFuture --bind 0.0.0.0
+
+  assets:
+    build:
+      context: .
+      dockerfile: Dockerfile.assets
+    working_dir: /app
+    user: "${UID:-1000}:${GID:-1000}"
+    volumes:
+      - ./:/app
+    # webpack --watch is the image CMD; install is a separate step
   

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "prestart": "yarn build",
     "build": "webpack",
     "start": "hugo server --disableFastRender",
-    "dev": "concurrently \"docker-compose up -d\" \"webpack --watch\""
+    "dev": "docker compose up"
   },
   "devDependencies": {
     "@babel/core": "^7.23.5",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -9,6 +9,12 @@ module.exports = {
     filename: 'app.js',
     publicPath: '/'
   },
+  watchOptions: {
+    aggregateTimeout: 500,
+    poll: 1000,
+    // ignore must cover relative and absolute output paths under Docker/WSL.
+    ignored: /(^|[\\/])(node_modules|static|public)([\\/]|$)/,
+  },
   module: {
     rules: [
       {


### PR DESCRIPTION
## Summary
- Local development now runs Hugo and Webpack entirely through Docker Compose, so host Node/Yarn/Corepack is not required day to day.
- Netlify’s production build path is unchanged.

## What changed
- Added `Dockerfile.assets` and a Compose `assets` service (Node 18 / Yarn 4) with host UID mapping
- Added `.yarnrc.yml` (`nodeLinker: node-modules`) for Webpack-compatible installs
- Updated Webpack `watchOptions` (poll + ignore `static`/`public`) to avoid Docker/WSL rebuild loops
- Pointed `yarn dev` at `docker compose up`; updated README, PROJECT, and TIMELINE

## Why
Makes local setup reproducible across machines and avoids Yarn/Corepack version friction when juggling multiple projects.

## Test plan
- [x] `docker compose build assets` and `docker compose run --rm assets yarn install`
- [x] `docker compose up` serves http://localhost:1313
- [x] CSS change under `src/` triggers a single Webpack rebuild (no watch loop)
- [x] Fresh `node_modules` reinstall via Compose after reclaiming file ownership