### PR TITLE
Document sequenced backlog plans for service pillars and SCP signposting

### DIFF
--- a/.cursor/plans/REQUIREMENTS.md
+++ b/.cursor/plans/REQUIREMENTS.md
@@ -4,8 +4,10 @@ Short backlog captured 2026-08. Each item has a brief plan; detailed design happ
 
 | Plan | Summary | Existing work |
 |------|---------|---------------|
-| [onedrive-policy-embeds.md](onedrive-policy-embeds.md) | Policies moved to OneDrive; restore accessible embeds | Local `feature/update-policies-and-procedures` (WIP) |
-| [homepage-scp-banner.md](homepage-scp-banner.md) | Homepage banner linking to Supporting Children's Pathways | None yet |
+| [three-service-pages.md](three-service-pages.md) | Three leaflet pillars: Mentoring, Construction, Alternative Learning | Mentoring + vocational page exist; ALP page missing |
+| [homepage-scp-banner.md](homepage-scp-banner.md) | Homepage bar + education CTAs → Supporting Children's Pathways | Depends on three-service-pages |
 | [content-testimonials-imagery.md](content-testimonials-imagery.md) | Content refresh, new testimonials, source/add pictures | Testimonials page + `feedback-quote` block already exist; images TBD with Tony |
+| [rebrand-styling.md](rebrand-styling.md) | Visual rebrand / styling pass (after structure + signposting) | None yet — brief only |
+| [onedrive-policy-embeds.md](onedrive-policy-embeds.md) | Policies moved to OneDrive; restore accessible embeds | Local `feature/update-policies-and-procedures` (WIP) |
 
 Delete individual plan files (and this index if empty) when the work ships.

--- a/.cursor/plans/homepage-scp-banner.md
+++ b/.cursor/plans/homepage-scp-banner.md
@@ -1,29 +1,73 @@
 # Homepage banner → Supporting Children's Pathways
 
-**Status:** Identified (Tony / Matt) — brief only; detailed planning when work starts  
+**Status:** Identified — starts **after** [three-service-pages.md](three-service-pages.md)  
 **Priority:** Medium — cross-site signposting for the sister charity  
-**Suggested branch:** `feature/homepage-scp-banner` from `develop`
+**Suggested branch:** `feature/homepage-scp-banner` from `develop`  
+**Depends on:** Three service pillars live (Mentoring, Construction, Alternative Learning)  
+**Follows / precedes:** After three-service-pages; before rebrand/styling.
 
 ## Goal
 
-Add a clear banner at the **top of the homepage** that links visitors to the sister site **Supporting Children's Pathways** (sibling repo: [`SCPCharity`](https://github.com/HandMatt/SCPCharity), production URL: https://www.supportingchildrenspathways.org/).
+1. **Homepage** — subtle top bar → Supporting Children's Pathways  
+   (https://www.supportingchildrenspathways.org/).
+2. **Service pages** — shared education-provision CTA on each of the three pillars  
+   (education arm spun off as charitable NFP).
+3. **SCP reciprocal banner** — out of scope; separate SCPCharity task.
 
 ## Context
 
-- This site already has a homepage **hero** (`hero_banner` → `layouts/partials/hero-banner.html`). The new item is a separate **top-of-page site notice / signpost**, not a hero redesign.
-- Sister site is a different Hugo project under `/home/matt/development/work/SCPCharity`.
+- Two sites, two purposes; visitors need clear signposting once the three Sporting Chance service pages exist.
+- Homepage already has a **hero**; this is a separate **slim site notice**, not a hero redesign.
+- Nav is `fixed top-0`; hero uses `margin-top: 4.8rem`. Prefer bar **inside the fixed header stack**.
+- Visual polish / rebrand is a later task — keep this shippable with existing `sc-*` tokens.
 
-## Brief plan
+## Decisions (kickoff)
 
-1. Agree copy with Tony (one short line + CTA label) and confirm the destination URL (home vs a specific landing page).
-2. Add a slim full-width banner above the main nav (or between nav and hero — decide at kickoff for visibility vs clutter).
-3. Homepage-only unless Tony wants it site-wide; prefer content/config driven (front matter or `config.toml` params) over hardcoding in the template.
-4. Match existing Tailwind / `sc-*` brand tokens; keep it one job (signpost), no card clutter.
-5. Check mobile: dismissible or not (default: not dismissible unless requested); link opens in same or new tab (confirm).
-6. PR into `develop`; delete this plan when shipped.
+| Topic | Decision |
+|-------|----------|
+| Visual weight | Subtle full-width bar |
+| CTA label | Learn more |
+| Homepage bar | Homepage only |
+| Education CTA | On **all three** service pages (stronger than the slim bar) |
+| Dismissible | No |
+| SCP reciprocal | Later — SCPCharity task |
+| Destination URL | https://www.supportingchildrenspathways.org/ |
 
-## Open questions (defer to task kickoff)
+### Copy drafts (Tony)
 
-- Exact wording and visual weight (subtle bar vs stronger callout)
-- Homepage only vs all pages
-- Whether SCP should reciprocate with a banner back to Sporting Chance
+Homepage bar:
+
+1. Education provision is now with Supporting Children's Pathways. [Learn more]
+2. Looking for education provision? Visit Supporting Children's Pathways. [Learn more]
+3. Our education charity is Supporting Children's Pathways. [Learn more]
+
+Service-page CTA: slightly fuller — spin-off / education provision → Learn more → SCP.
+
+### Still confirm before build
+
+1. Final wording.
+2. Same tab vs new tab (`target="_blank"` + `rel="noopener"` recommended).
+
+## Implementation plan
+
+1. Agree final copy with Tony.
+2. Slim banner partial; homepage-only via front matter / params; fix header/hero offsets.
+3. Shared education CTA on Mentoring, Construction, and Alternative Learning pages.
+4. Match existing Tailwind / `sc-*`; one job (signpost); no rebrand in this PR.
+5. PR into `develop`; delete this plan when shipped.
+6. File reciprocal banner task on SCPCharity.
+
+## Out of scope
+
+- Creating/renaming the three service pages (prior plan)
+- Rebrand / per-pillar leaflet styling (later plan)
+- Reciprocal banner on supportingchildrenspathways.org
+- Hero redesign; site-wide notice; dismissible behaviour
+
+## Done when
+
+- [ ] Homepage subtle bar + Learn more → SCP
+- [ ] Each of the three service pages has education CTA → SCP
+- [ ] Offsets OK on desktop and mobile
+- [ ] SCP reciprocal task noted elsewhere
+- [ ] This plan file deleted after merge

--- a/.cursor/plans/rebrand-styling.md
+++ b/.cursor/plans/rebrand-styling.md
@@ -1,0 +1,19 @@
+# Rebrand / styling
+
+**Status:** Identified — do **after** three service pages and SCP signposting  
+**Priority:** Lower / later  
+**Suggested branch:** `feature/rebrand-styling` from `develop`
+
+## Goal
+
+Visual refresh aligned with current brand direction (and leaflet look where useful), without blocking structural or signposting work.
+
+## Notes
+
+- Keep brief until kickoff; detailed planning then.
+- Likely touches Tailwind/`sc-*` tokens, headers, service page atmosphere — not content architecture.
+- Do not invent a large redesign in the earlier PRs.
+
+## Out of scope (for now)
+
+- Full detailed design system until this task starts

--- a/.cursor/plans/three-service-pages.md
+++ b/.cursor/plans/three-service-pages.md
@@ -1,0 +1,57 @@
+# Three service pages (leaflet-aligned)
+
+**Status:** Identified — do **before** homepage SCP banner  
+**Priority:** High — structural/content prerequisite for clear signposting  
+**Suggested branch:** `feature/three-service-pages` from `develop`  
+**Copy source:** `Sporting Chance Project Leaflets (1).pdf` (3 pages)  
+**Follows / blocks:** Blocks [homepage-scp-banner.md](homepage-scp-banner.md). Rebrand/styling is a later task.
+
+## Goal
+
+Align the site with the leaflet’s three pillars:
+
+1. Mentoring & Life Skills  
+2. Construction Workshops  
+3. Alternative Learning (new page)
+
+Wire nav + Services hub so each pillar has its own page and correct links.
+
+## Context
+
+- Site today: mentoring ✓; construction lives at `/alternative-learning-provision` titled “Vocational”; no dedicated Alternative Learning page.
+- Naming collision: `/alternative-learning-provision` is construction content. Untangle when adding Alternative Learning.
+- Leaflet ages/focus: Mentoring 5–18; Construction 14–18; Alternative Learning 5–18 (functional skills, cooking, money, animal care, sport, employability).
+
+## Decisions / open questions (kickoff)
+
+| Topic | Notes |
+|-------|--------|
+| Construction URL | Keep `/alternative-learning-provision` or move to `/construction-workshops` (+ redirect)? |
+| New page slug | `/alternative-learning` (preferred if construction keeps or moves off the ALP slug) |
+| Copy fidelity | Leaflet as source of truth for intros + “Our sessions include”; expand with existing page patterns |
+| Cross-links | Mentoring ↔ Construction ↔ Alternative Learning on each page |
+| SCP / education CTA | **Out of scope** — next plan (`homepage-scp-banner`) |
+
+## Implementation plan
+
+1. Retitle vocational page → Construction Workshops; optional URL rename + redirect.
+2. Add Alternative Learning page (same templates: `generic-header`, `icon-grid`, `centred-text`, `cta-block`) from leaflet page 3.
+3. Refresh Mentoring page from leaflet if needed (keep structure).
+4. Update `config.toml` Services children → three items with correct labels/URLs.
+5. Fix `content/services.md` three-columns + detail sections so links match the three pages.
+6. Fix cross-links between the three service pages.
+7. PR into `develop`; delete this plan when shipped.
+
+## Out of scope
+
+- Homepage SCP bar / education spin-off CTAs ([homepage-scp-banner.md](homepage-scp-banner.md))
+- Visual rebrand / leaflet colour schemes per pillar
+- Reciprocal banner on SCPCharity
+
+## Done when
+
+- [ ] Three service pages exist and match leaflet pillars
+- [ ] Nav + Services hub list all three with correct links
+- [ ] Old construction URL handled if renamed
+- [ ] No SCP education CTA yet (that’s the next task)
+- [ ] This plan file deleted after merge


### PR DESCRIPTION
## Summary
- Capture the agreed work order as docs-only plans: three service pages first, then SCP signposting, then rebrand.
- Narrow the homepage SCP banner plan so it no longer includes creating the third service page.

## What changed
- Added `three-service-pages.md` and `rebrand-styling.md`
- Updated `homepage-scp-banner.md` (depends on three pillars; CTAs on all three service pages)
- Updated `REQUIREMENTS.md` backlog index

## Why
Keep planning commits separate from implementation branches (`feature/three-service-pages`, `feature/homepage-scp-banner`, `feature/rebrand-styling`).

## Test plan
- [X] Confirm plan files read clearly and the dependency order matches intent
- [X] No site/code changes in this PR