### PR TITLE
Fix SCP notice header offset overlapping page content

### DIFF
--- a/layouts/partials/blocks/cta-block.html
+++ b/layouts/partials/blocks/cta-block.html
@@ -7,7 +7,7 @@
         <p class="md:text-xl sm:text-xl opacity-75">{{ markdownify . }}</p>
         {{ end }}
         <div class="py-3 flex justify-center">
-            <div class="my-12"><a href="{{ .Params.buttonlink}}"
+            <div class="my-12"><a href="{{ .Params.buttonlink | default "/" }}"
                     class="trans-02 border-2 hover:border-sc-yellow hover:bg-sc-yellow shadow my-5 text-xl border-grey-darker rounded mt-4 p-4 text-right font-semibold no-underline text-black hover:text-white"
                     >{{ .Params.buttontext }} →</a></div>
         </div>

--- a/src/css/_custom.css
+++ b/src/css/_custom.css
@@ -59,7 +59,7 @@ body.has-scp-site-notice {
 }
 
 main {
-    margin-top: 4.8rem;
+    margin-top: var(--site-header-offset);
 }
 
 .scp-site-notice {

--- a/static/css/main.css
+++ b/static/css/main.css
@@ -132,7 +132,7 @@ body.has-scp-site-notice {
 }
 
 main {
-    margin-top: 4.8rem;
+    margin-top: var(--site-header-offset);
 }
 
 .scp-site-notice {


### PR DESCRIPTION
## Summary
- Align `main` with the taller fixed header when the homepage SCP site notice is shown, so content no longer sits under the nav.
- Harden the CTA block so a missing `buttonlink` falls back to `/` instead of an empty `href`.

## What changed
- `src/css/_custom.css` and `static/css/main.css`: `main` uses `var(--site-header-offset)`
- `layouts/partials/blocks/cta-block.html`: `buttonlink | default "/"`

## Test plan
- [x] Homepage with SCP notice: content clears the notice + nav on desktop and mobile
- [x] Non-homepage pages: header clearance still looks correct
- [x] About CTA still links to `/contact`